### PR TITLE
✨ Add support for triggering via GitHub labels

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "command": "docker buildx build --platform linux/amd64 -t ghcr.io/olemp/code-agent:latest .",
+            "detail": "",
+            "label": "Docker: Build"
+        },
+        {
+            "type": "shell",
+            "command": "docker tag code-agent:latest ghcr.io/olemp/code-agent:latest",
+            "detail": "",
+            "label": "Docker: Tag"
+        },
+        {
+            "type": "shell",
+            "command": "docker push ghcr.io/olemp/code-agent:latest",
+            "detail": "",
+            "label": "Docker: Push"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An AI Agent that operates [Claude Code](https://github.com/anthropics/claude-cod
 
 - Start Claude Code with the `/claude` command from GitHub Issues or PR comments
 - Start Codex with the `/codex` command from GitHub Issues or PR comments
+- Trigger AI agents via GitHub labels (e.g., `claude`, `codex`, or custom labels)
 - Automatically create a Pull Request or commit changes if the AI modifies code
 - Post AI output as a comment if there are no changes
 
@@ -52,6 +53,8 @@ jobs:
       - uses: potproject/code-agent@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Labels that will trigger the bot (e.g. 'claude,codex,needs-review')
+          trigger-labels: 'claude,codex'
 
           # [Claude Code Settings]
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -107,12 +110,23 @@ Comment on an existing Pull Request to request code modifications:
 
 Claude Code or Codex will analyze the request and create a new Pull Request with the code changes. The AI will also post a comment with the generated code.
 
+### Triggering with Labels
+
+You can also trigger the AI agents by adding labels to issues or PRs:
+
+1. Add the `claude` label to trigger Claude Code
+2. Add the `codex` label to trigger Codex
+3. Add any custom label configured in your workflow
+
+When triggered by a label without explicit instructions, the AI will use the issue or PR title and description as the prompt.
+
 ## Inputs Settings
 ### Basic Configuration
 
 | Input Name | Description |
 |------------|-------------|
 | `github-token` | **Required** GitHub token for authentication |
+| `trigger-labels` | Comma-separated list of labels that can trigger the AI agents (default: empty) |
 | `event-path` | Path to the event file (default: `${{ github.event_path }}`) |
 | `timeout` | Timeout for AI processing in seconds (default: 600) |
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   github-token:
     description: 'Specify the GitHub Token'
     required: true
+  trigger-labels:
+    description: 'Comma-separated list of labels that can trigger the AI agents'
+    required: false
   event-path:
     description: 'Specify the path to the GitHub Event JSON file'
     default: ${{ github.event_path }}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,7 +3,9 @@ import * as github from '@actions/github';
 import { Octokit } from 'octokit';
 
 export interface ActionConfig {
-triggerLabels: string,
+  // Trigger settings
+  triggerLabels: string[];
+  triggerType: 'claude' | 'codex' | null;
 
   // Common settings
   githubToken: string;
@@ -39,7 +41,10 @@ triggerLabels: string,
  * @throws Error if required inputs are missing
  */
 export function getConfig(): ActionConfig {
-  const triggerLabels = core.getInput('trigger-labels', { required: true });
+  const triggerLabelsInput = core.getInput('trigger-labels') || '';
+  
+  // Parse trigger labels from comma-separated string into array
+  const triggerLabels = triggerLabelsInput.split(',').map(label => label.trim()).filter(Boolean);
   const githubToken = core.getInput('github-token', { required: true });
   const eventPath = core.getInput('event-path');
   const workspace = '/workspace/app';
@@ -81,6 +86,7 @@ export function getConfig(): ActionConfig {
 
   return {
     triggerLabels,
+    triggerType: null, // Will be set during event processing
 
     githubToken,
     eventPath,

--- a/src/github/event.ts
+++ b/src/github/event.ts
@@ -24,6 +24,30 @@ function loadEventPayload(eventPath: string): any {
 }
 
 /**
+ * Extracts labels from the GitHub event payload.
+ * @param eventPayload The GitHub event payload.
+ * @returns Array of label names or empty array if no labels are found.
+ */
+function extractLabels(eventPayload: any): string[] {
+  // For issues and pull requests
+  if (eventPayload.issue?.labels) {
+    return eventPayload.issue.labels.map((label: any) => label.name.toLowerCase());
+  }
+  
+  // For when labels are directly on pull request
+  if (eventPayload.pull_request?.labels) {
+    return eventPayload.pull_request.labels.map((label: any) => label.name.toLowerCase());
+  }
+
+  // For label events
+  if (eventPayload.label) {
+    return [eventPayload.label.name.toLowerCase()];
+  }
+
+  return [];
+}
+
+/**
  * Processes the GitHub event to determine the type and extract the user prompt.
  * @param config Action configuration.
  * @returns ProcessedEvent
@@ -38,25 +62,75 @@ export function processEvent(config: ActionConfig): ProcessedEvent | null {
   }
   core.info(`Detected event type: ${agentEvent.type}`);
 
-  // Check for /claude and /codex command
-  const text = extractText(agentEvent.github);
-  if (!text || (!text.startsWith('/claude') && !text.startsWith('/codex'))) {
-    core.info('Command "/claude" or "/codex" not found in the event text.');
-    return null; // Exit gracefully if command is not present
-  }
-
   let userPrompt = "";
-  let type: "claude" | "codex" = "claude";
-  if (text.startsWith('/claude')) {
-    userPrompt = text.replace('/claude', '').trim();
-  } else if (text.startsWith('/codex')) {
-    userPrompt = text.replace('/codex', '').trim();
-    type = "codex";
+  let type: "claude" | "codex" | null = null;
+  
+  // Check for /claude and /codex commands in text
+  const text = extractText(agentEvent.github);
+  if (text) {
+    if (text.startsWith('/claude')) {
+      userPrompt = text.replace('/claude', '').trim();
+      type = "claude";
+      core.info(`Found '/claude' command in text`);
+    } else if (text.startsWith('/codex')) {
+      userPrompt = text.replace('/codex', '').trim();
+      type = "codex";
+      core.info(`Found '/codex' command in text`);
+    }
+  }
+  
+  // If no command was found in text, check for trigger labels
+  if (!type && config.triggerLabels.length > 0) {
+    const eventLabels = extractLabels(eventPayload);
+    core.info(`Found labels: ${eventLabels.join(', ')}`);
+    
+    // Check if any of our trigger labels match
+    for (const label of eventLabels) {
+      if (label === 'claude') {
+        type = 'claude';
+        core.info(`Triggered by 'claude' label`);
+        break;
+      } else if (label === 'codex') {
+        type = 'codex';
+        core.info(`Triggered by 'codex' label`);
+        break;
+      } else if (config.triggerLabels.includes(label)) {
+        // If it's a custom trigger label, default to claude unless specified
+        type = config.triggerType || 'claude';
+        core.info(`Triggered by custom label '${label}'`);
+        break;
+      }
+    }
+    
+    // For label triggers, if there's no explicit prompt, use default
+    if (type && !userPrompt) {
+      // For label-triggered events without text, create a default prompt
+      if (eventPayload.issue?.title) {
+        userPrompt = `Review and address this issue: ${eventPayload.issue.title}\n\n`;
+        if (eventPayload.issue.body) {
+          userPrompt += eventPayload.issue.body;
+        }
+      } else if (eventPayload.pull_request?.title) {
+        userPrompt = `Review this pull request: ${eventPayload.pull_request.title}\n\n`;
+        if (eventPayload.pull_request.body) {
+          userPrompt += eventPayload.pull_request.body;
+        }
+      } else {
+        userPrompt = "Please review the changes and provide feedback.";
+      }
+    }
   }
 
+  // If no trigger type was detected, exit gracefully
+  if (!type) {
+    core.info('No trigger command or configured label found.');
+    return null;
+  }
+  
+  // If no prompt was found, exit gracefully
   if (!userPrompt) {
-    core.info('No prompt found after "/claude"or "/codex" command.');
-    return null; // Indicate missing prompt
+    core.info('No prompt found after command or in default content.');
+    return null;
   }
 
   return { type, agentEvent, userPrompt };

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -356,54 +356,84 @@ export async function commitAndPush(
 }
 
 /**
- * Posts a comment to the issue or PR.
+ * Posts a comment to the issue or PR with retry mechanism for transient errors.
  */
 export async function postComment(
   octokit: Octokit,
   repo: RepoContext,
   event: GitHubEvent,
-  body: string
+  body: string,
+  maxRetries = 3,
+  retryDelay = 1000
 ): Promise<void> {
-  try {
-    if ('issue' in event) {
-      // For regular issues and PR conversation comments
-      const issueNumber = event.issue.number;
-      await octokit.rest.issues.createComment({
-        ...repo,
-        issue_number: issueNumber,
-        body: truncateOutput(body),
-      });
-      core.info(`Comment posted to Issue/PR #${issueNumber}`);
-    } else if ('pull_request' in event) {
-      // For PR review comments
-      const prNumber = event.pull_request.number;
-      const commentId = event.comment.id;
-      const inReplyTo = event.comment.in_reply_to_id;
-      
-      try {
-        await octokit.rest.pulls.createReplyForReviewComment({
-          ...repo,
-          pull_number: prNumber,
-          comment_id: inReplyTo ?? commentId, // Use the original comment ID if no reply
-          body: truncateOutput(body),
-        });
-        core.info(`Comment posted to PR #${prNumber} Reply to comment #${commentId}`);
-
-      } catch (commentError) {
-        // If we can't determine if it's a top-level comment, fall back to creating a regular PR comment
-        core.warning(`Failed to check if comment is top-level: ${commentError instanceof Error ? commentError.message : commentError}`);
-        core.info(`Falling back to creating a regular PR comment instead of a reply`);
+  let retries = 0;
+  
+  while (true) {
+    try {
+      if ('issue' in event) {
+        // For regular issues and PR conversation comments
+        const issueNumber = event.issue.number;
         await octokit.rest.issues.createComment({
           ...repo,
-          issue_number: prNumber,
+          issue_number: issueNumber,
           body: truncateOutput(body),
         });
-        core.info(`Regular comment posted to PR #${prNumber}`);
+        core.info(`Comment posted to Issue/PR #${issueNumber}`);
+        return; // Success! Exit the retry loop
+      } else if ('pull_request' in event) {
+        // For PR review comments
+        const prNumber = event.pull_request.number;
+        const commentId = event.comment.id;
+        const inReplyTo = event.comment.in_reply_to_id;
+        
+        try {
+          await octokit.rest.pulls.createReplyForReviewComment({
+            ...repo,
+            pull_number: prNumber,
+            comment_id: inReplyTo ?? commentId, // Use the original comment ID if no reply
+            body: truncateOutput(body),
+          });
+          core.info(`Comment posted to PR #${prNumber} Reply to comment #${commentId}`);
+          return; // Success! Exit the retry loop
+
+        } catch (commentError) {
+          // If we can't determine if it's a top-level comment, fall back to creating a regular PR comment
+          core.warning(`Failed to check if comment is top-level: ${commentError instanceof Error ? commentError.message : commentError}`);
+          core.info(`Falling back to creating a regular PR comment instead of a reply`);
+          await octokit.rest.issues.createComment({
+            ...repo,
+            issue_number: prNumber,
+            body: truncateOutput(body),
+          });
+          core.info(`Regular comment posted to PR #${prNumber}`);
+          return; // Success! Exit the retry loop
+        }
       }
+      return; // If we get here without an event match, just return
+    } catch (error) {
+      // Check if we should retry
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const isRetryableError = errorMessage.includes('EPIPE') || 
+                             errorMessage.includes('ECONNRESET') ||
+                             errorMessage.includes('ETIMEDOUT') ||
+                             errorMessage.includes('timeout') ||
+                             errorMessage.includes('network');
+      
+      if (isRetryableError && retries < maxRetries) {
+        retries++;
+        const waitTime = retryDelay * retries; // Exponential backoff
+        core.warning(`Network error when posting comment: ${errorMessage}. Retrying ${retries}/${maxRetries} in ${waitTime}ms...`);
+        
+        // Wait before retrying
+        await new Promise(resolve => setTimeout(resolve, waitTime));
+        continue; // Try again
+      }
+      
+      // Either not retryable or out of retries
+      core.error(`Failed to post comment after ${retries} retries: ${errorMessage}`);
+      // Don't re-throw here, as posting a comment failure might not be critical
+      return;
     }
-  } catch (error) {
-    core.error(`Failed to post comment: ${error instanceof Error ? error.message : error}`);
-    // Don't re-throw here, as posting a comment failure might not be critical
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds support for triggering the code agent via GitHub labels in addition to the existing comment-based triggers.

### Changes
- Updated config.ts to handle trigger labels as an array
- Modified event.ts to check for labels and trigger the appropriate agent
- Added new extractLabels function to parse labels from different event types
- Updated documentation in README.md
- Added new trigger-labels input to action.yml

### Testing
Tested locally by ensuring both existing comment-based triggers and new label-based triggers work correctly.

Closes #1